### PR TITLE
fix(i18n): incorrect information collection path in single language mode

### DIFF
--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -98,7 +98,8 @@ const jottingWords = (await Promise.all(jottings.map(async jotting => (await ren
 const totalWords = noteWords + jottingWords;
 
 // Check if policy file exists for current locale
-const policy = await getEntry("information", `${monolocale ? "" : `${locale}/`}policy`);
+const localePrefix = monolocale ? "" : `${locale}/`;
+const policy = await getEntry("information", `${localePrefix}policy`);
 ---
 
 <footer class="flex flex-col sm:flex-row items-center justify-between gap-2 mt-8 mb-5 sm:mb-3 text-size-sm font-mono">

--- a/src/pages/[...locale]/about.astro
+++ b/src/pages/[...locale]/about.astro
@@ -14,9 +14,11 @@ const { locale = config.i18n.defaultLocale } = Astro.params;
 
 const t = i18nit(locale);
 
-const introduction = await getEntry("information", `${monolocale ? "" : `${locale}/`}introduction`);
-const linkroll = await getEntry("information", `${monolocale ? "" : `${locale}/`}linkroll`);
-const chronicle = (await getEntry("information", `${monolocale ? "" : `${locale}/`}chronicle`))?.data;
+const localePrefix = monolocale ? "" : `${locale}/`;
+
+const introduction = await getEntry("information", `${localePrefix}introduction`);
+const linkroll = await getEntry("information", `${localePrefix}linkroll`);
+const chronicle = (await getEntry("information", `${localePrefix}chronicle`))?.data;
 
 const { Content: Introduction } = introduction ? await render(introduction) : ({} as any);
 const { Content: Linkroll } = linkroll ? await render(linkroll) : ({} as any);

--- a/src/pages/[...locale]/policy.astro
+++ b/src/pages/[...locale]/policy.astro
@@ -14,7 +14,8 @@ const { locale = config.i18n.defaultLocale } = Astro.params;
 
 const t = i18nit(locale);
 
-const policy = await getEntry("information", `${monolocale ? "" : `${locale}/`}policy`);
+const localePrefix = monolocale ? "" : `${locale}/`;
+const policy = await getEntry("information", `${localePrefix}policy`);
 const { Content } = policy ? await render(policy) : ({} as any);
 ---
 


### PR DESCRIPTION
## Problem

When using single language mode (only one locale configured), the `information` collection entries fail to load, causing pages like `/about` and `/policy` to display without content.

**Error messages in console:**
```
Entry information → /introduction was not found.
Entry information → /linkroll was not found.
Entry information → /chronicle was not found.
Entry information → /policy was not found.
```

**Root cause:**  
The template literal `${monolocale ? "" : locale}/entry` produces an incorrect path with a leading slash (`/introduction`), while the actual file path is `introduction` (without the leading slash).

## Steps to Reproduce

1. Configure single language mode in `site.config.ts`:
   ```typescript
   i18n: {
       locales: ["zh-cn"],
       defaultLocale: "zh-cn"
   }
   ```

2. Move content files from language subdirectories to collection root:
   ```
   src/content/information/zh-cn/introduction.md
   → src/content/information/introduction.md
   ```

3. Run `pnpm dev` and navigate to `/about` or `/policy`

4. The pages appear blank and the console reports “Entry not found”.

## Solution

This PR shows one possible way to construct the path correctly using template string concatenation:

**Before:**
```typescript
// produces "/introduction"
`${monolocale ? "" : locale}/introduction`
```

**After:**
```typescript
// produces "introduction"
`${monolocale ? "" : `${locale}/`}introduction`
```

## Other Solutions & Additional Notes

```typescript
monolocale ? "introduction" : `${locale}/introduction`
```

or

```typescript
let path: string;
if (monolocale) {
    path = "introduction";
} else {
    path = `${locale}/introduction`;
}
const introduction = await getEntry("information", path);
```

This PR provides a minimal version of the fix.
Please feel free to modify or adjust it according to what works best for the project.