### PR TITLE
fix(config): site.config.ts compatible with nodejs

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -1,6 +1,6 @@
 import siteConfig, { providers } from "./src/utils/config";
 
-const env = import.meta.env;
+const env = import.meta.env ?? {};
 
 const config = siteConfig({
 	title: "ThoughtLite",


### PR DESCRIPTION
## Description

When running the `pnpm new` script (which uses `tsx` to execute `scripts/new.ts`), the following error occurs:

<img width="1638" height="550" alt="图片" src="https://github.com/user-attachments/assets/77cb25dd-9f68-45d4-af83-d10655873a38" />


## Root Cause

The issue occurs because `site.config.ts` uses `import.meta.env`, which is provided by Vite/Astro runtime but is `undefined` in a plain Node.js environment when running scripts with `tsx`.

When `scripts/new.ts` imports `site.config.ts`:
```typescript
import config, { monolocale } from "../site.config";
```

The config file is evaluated immediately, and accessing properties on `undefined` causes a TypeError.

## Solution

Modified line 3 in `site.config.ts` from:
```typescript
const env = import.meta.env;
```

to:
```typescript
const env = import.meta.env ?? {};
```

This uses the nullish coalescing operator to provide an empty object when `import.meta.env` is undefined, allowing the config file to work in both:
- Astro/Vite runtime (where `import.meta.env` exists)
- Node.js `tsx` environment (where `import.meta.env` is undefined)

## Testing

After the fix, `pnpm new` runs successfully without errors. The script properly displays the interactive CLI prompts.

This is a minimal, non-breaking change that only affects the environment variable initialization. Please feel free to modify or adjust it according to what works best for the project.