### PR TITLE
UI Optimization: Set the scrollbar to background color

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -68,7 +68,7 @@
 
 	::-webkit-scrollbar-thumb {
 		border-radius: 5px;
-		background-color: var(--primary-color);
+		background-color: var(--background-color);
 	}
 
 	*:focus-visible {


### PR DESCRIPTION
Since we've already have the progress indicator in the "go top button", so we actually don't need scroll bar to tell where's the position of the article. Also, the scrollbar will causing the issue #132, so I removed it.

